### PR TITLE
SG2042: Workaround for Sv39 on SG2042

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1846,6 +1846,81 @@ MergeMemoryMapDescriptor (
   return NEXT_MEMORY_DESCRIPTOR (MemoryMapDescriptor, DescriptorSize);
 }
 
+STATIC UINT8 TempMemoryMap[EFI_PAGE_SIZE * 2];
+
+STATIC
+EFI_STATUS
+SplitMemoryMap(
+  IN EFI_MEMORY_DESCRIPTOR      *MemoryMapStart,
+  IN OUT UINTN                  *UsedMemoryMapSize,
+  IN UINTN                      TotalMemoryMapSize,
+  IN UINTN                      DescriptorSize,
+  IN UINTN                      From,
+  IN UINTN                      Grain
+  )
+{
+  INTN                          TempIterator;
+  INTN                          Iterator;
+  EFI_PHYSICAL_ADDRESS          Left, TempStart;
+  EFI_MEMORY_DESCRIPTOR         *SourceDescriptor;
+  EFI_MEMORY_DESCRIPTOR         *DestinationDescriptor;
+
+  TempIterator = 0;
+
+  for (Iterator = 0, SourceDescriptor = MemoryMapStart;
+       Iterator < (*UsedMemoryMapSize) / DescriptorSize;
+       ++Iterator, SourceDescriptor = NEXT_MEMORY_DESCRIPTOR(SourceDescriptor, DescriptorSize)) {
+    if ( SourceDescriptor->PhysicalStart > From &&
+         SourceDescriptor->NumberOfPages * EFI_PAGE_SIZE > Grain ) {
+      /* split this region */
+      TempIterator += ((SourceDescriptor->NumberOfPages * EFI_PAGE_SIZE + (Grain - 1)) / Grain) - 1;
+    }
+  }
+
+  if (TempIterator * DescriptorSize + *UsedMemoryMapSize> TotalMemoryMapSize) {
+    *UsedMemoryMapSize += TempIterator * DescriptorSize;
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  TempIterator = 0;
+  DestinationDescriptor = (EFI_MEMORY_DESCRIPTOR *)TempMemoryMap;
+
+  for (Iterator = 0, SourceDescriptor = MemoryMapStart;
+       Iterator < (*UsedMemoryMapSize) / DescriptorSize;
+       ++Iterator, SourceDescriptor = NEXT_MEMORY_DESCRIPTOR(SourceDescriptor, DescriptorSize)) {
+    if ( SourceDescriptor->PhysicalStart > From &&
+         SourceDescriptor->NumberOfPages * EFI_PAGE_SIZE > Grain ) {
+      /* split this region */
+      Left = SourceDescriptor->NumberOfPages * EFI_PAGE_SIZE;
+      TempStart = SourceDescriptor->PhysicalStart;
+      while (Left > Grain) {
+        CopyMem(DestinationDescriptor, SourceDescriptor, DescriptorSize);
+        DestinationDescriptor->PhysicalStart = TempStart;
+        DestinationDescriptor->NumberOfPages = Grain / EFI_PAGE_SIZE;
+        DestinationDescriptor = NEXT_MEMORY_DESCRIPTOR(DestinationDescriptor, DescriptorSize);
+        ++TempIterator;
+        TempStart += Grain;
+        Left -= Grain;
+      }
+      if (Left) {
+        CopyMem(DestinationDescriptor, SourceDescriptor, DescriptorSize);
+        DestinationDescriptor->PhysicalStart = TempStart;
+        DestinationDescriptor->NumberOfPages = Left / EFI_PAGE_SIZE;
+        DestinationDescriptor = NEXT_MEMORY_DESCRIPTOR(DestinationDescriptor, DescriptorSize);
+        ++TempIterator;
+      }
+    } else {
+      CopyMem(DestinationDescriptor, SourceDescriptor, DescriptorSize);
+      DestinationDescriptor = NEXT_MEMORY_DESCRIPTOR(DestinationDescriptor, DescriptorSize);
+      ++TempIterator;
+    }
+  }
+  *UsedMemoryMapSize = TempIterator * DescriptorSize;
+  CopyMem(MemoryMapStart, TempMemoryMap, *UsedMemoryMapSize);
+
+  return EFI_SUCCESS;
+}
+
 /**
   This function returns a copy of the current memory map. The map is an array of
   memory descriptors, each of which describes a contiguous block of memory.
@@ -2155,6 +2230,13 @@ CoreGetMemoryMap (
   }
 
   MergeMemoryMap (MemoryMapStart, &BufferSize, Size);
+
+  Status = SplitMemoryMap (MemoryMapStart, &BufferSize, *MemoryMapSize, Size,
+                           256UL * 1024 * 1024 * 1024,
+                           16UL * 1024 * 1024 * 1024);
+  if (EFI_ERROR(Status))
+    return Status;
+
   MemoryMapEnd = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMapStart + BufferSize);
 
   Status = EFI_SUCCESS;

--- a/MdePkg/Include/RiscV64/ProcessorBind.h
+++ b/MdePkg/Include/RiscV64/ProcessorBind.h
@@ -98,9 +98,9 @@ typedef INT64 INTN __attribute__ ((aligned (8)));
 #define MAX_ADDRESS  0xFFFFFFFFFFFFFFFFULL
 
 ///
-/// Maximum usable address at boot time (48 bits using 4 KB pages in Supervisor mode)
+/// Maximum usable address at boot time (39 bits using 4 KB pages in Supervisor mode)
 ///
-#define MAX_ALLOC_ADDRESS  0xFFFFFFFFFFFFULL
+#define MAX_ALLOC_ADDRESS  ((1ULL << 38) - 1)
 
 ///
 /// Maximum legal RISC-V INTN and UINTN values.


### PR DESCRIPTION
On SG2042, our memory map is

+------+ 0x0100_0000_0000
|      |
|      |
|  IO  |
| 256G |
|      |
|      |
+------+ 0x00C0_0000_0000
|      |
|      |
| DRAM |
| 256G |
|      |
|      |
+------+ 0x0080_0000_0000
|      |
|      |
|  IO  |
| 256G |
|      |
|      |
+------+ 0x0040_0000_0000 (Start of Sv39 Nagative Address)
|      |
|      |
| DRAM |
| 256G |
|      |
|      |
-------- 0x0000_0000_0000

SG2042 uses T-HEAD C920v1 as its CPU core IP. Which only support Sv39 MMU model. It doesn't support Sv48 or above.
On Sv39 MMU model, address larger than 0x0040_0000_0000 should uses nagative address (eg. 0xffffffc000000000). But EDK2, grub2 and linux kernel efi stub can't deal with such address conversions (eg. 0x0040_0000_0000 to 0xffffffc000000000). So we need add a workaround to make sure, EDK2 won't allocate memory equal to or above 0x0040_0000_0000. Changing MAX_ALLOC_ADDRESS to 0x0040_0000_0000 fixes this issue.

So after changing MAX_ALLOC_ADDRESS, grub2 failed in allocate memory. Because grub2 allocate pages with a physical address. Where to allocate pages is determined by the largest memory region delcared by EDK2. grub2 will iterate all memory regions through GetMemoryMap boot service, then choose the largest one. Without this workaround, grub2 always allocate pages in region 0x0040_0000_0000 - 0x00c0_0000_0000, because EDK2 already allocate some pages in region 0x0000_0000_0000 - 0x0040_0000_0000. We split region 0x0040_0000_0000
- 0x00c0_0000_0000 with 16GB blocks. So in grub2, it will find the largest region below 0x0040_0000_0000.

# Description

<_Include a description of the change and why this change was made._>

<_For each item, place an "x" in between `[` and `]` if true. Example: `[x]` (you can also check items in GitHub UI)_>

<_Create the PR as a Draft PR if it is only created to run CI checks._>

<_Delete lines in \<\> tags before creating the PR._>

- [ ] Breaking change?
  - **Breaking change** - Does this PR cause a break in build or boot behavior?
  - Examples: Does it add a new library class or move a module to a different repo.
- [ ] Impacts security?
  - **Security** - Does this PR have a direct security impact?
  - Examples: Crypto algorithm change or buffer overflow fix.
- [ ] Includes tests?
  - **Tests** - Does this PR include any explicit test code?
  - Examples: Unit tests or integration tests.

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
